### PR TITLE
Add envar to overwride dnsmasq resolv file

### DIFF
--- a/src/settings.js
+++ b/src/settings.js
@@ -52,7 +52,7 @@ var settings = {
 	dnsmasq: {
 		hostsPath: '/hosts/',
 		hostsFile: 'hosts.serf',
-		resolvFile: '/resolv.conf'
+		resolvFile: process.env.EYEOS_RUN_SERVER_RESOLV || '/resolv.conf'
 	},
 	gatewayResolver: {
 		resolvFile: '/etc/resolv.conf',


### PR DESCRIPTION
In the alpine based version of the sync server we can't use /resolv.conf
because dnsmasq fails to open it. After investigating for a while I have
given up for now and instead I will move the file elsewhere.
