### PR TITLE
GatewayResolver: Do not update the /etc/resolv.conf

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eyeos-run-server",
-  "version": "0.0.118",
+  "version": "0.0.119",
   "description": "encapsulates different process as one",
   "main": "src/eyeos-run-server.js",
   "author": "eyeOS",

--- a/src/lib/modules/GatewayResolver.js
+++ b/src/lib/modules/GatewayResolver.js
@@ -33,14 +33,8 @@ GatewayResolver.prototype.start = function(callback) {
 			return;
 		}
 
-		var nameserver = 'nameserver ' + gateway + '\n';
-		fs.writeFile(self.settings.gatewayResolver.resolvFile, nameserver, function(err) {
-			if (err) {
-				callback(err);
-			}
-			fs.appendFile(self.settings.gatewayResolver.hostsFile, gateway + " gateway", function(err) {
-				callback(err);
-			});
+		fs.appendFile(self.settings.gatewayResolver.hostsFile, gateway + " gateway", function(err) {
+			callback(err);
 		});
 	});
 };

--- a/src/settings.js
+++ b/src/settings.js
@@ -55,7 +55,6 @@ var settings = {
 		resolvFile: process.env.EYEOS_RUN_SERVER_RESOLV || '/resolv.conf'
 	},
 	gatewayResolver: {
-		resolvFile: '/etc/resolv.conf',
 		hostsFile: '/etc/hosts'
 	},
 	microServiceChecker: {


### PR DESCRIPTION
The only microservice which used this was proxy. From now on proxy has
its own dnsmasq which is used by eyeos-run-server and for nginx it uses
the dnsmasq microservice. (See the proxy commit logs for details).

We still need the 'gateway' to be added to the hosts, since it is used
by the nginx conf as the resolver.
